### PR TITLE
updating to the new file_prefix format and adding tests.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ flake8
 git+git://github.com/NSLS-II/ophyd@ophyd-for-suitcase-utils
 pytest >=3.9
 sphinx
-suitcase-utils[test_fixtures] >=0.1.1
+suitcase-utils[test_fixtures] >=0.1.4rc1
 # These are dependencies of various sphinx extensions for documentation.
 ipython
 matplotlib

--- a/suitcase/json_metadata/tests/conftest.py
+++ b/suitcase/json_metadata/tests/conftest.py
@@ -1,4 +1,5 @@
 from bluesky.tests.conftest import RE  # noqa
 from ophyd.tests.conftest import hw  # noqa
 from suitcase.utils.tests.conftest import (  # noqa
-    example_data, generate_data, detector_list, event_type, plan_type) # noqa
+    example_data, generate_data, detector_list, event_type, plan_type,  # noqa
+    file_prefix_list)  # noqa

--- a/suitcase/json_metadata/tests/tests.py
+++ b/suitcase/json_metadata/tests/tests.py
@@ -70,3 +70,26 @@ def test_export_with_kwargs(tmp_path, example_data, kwargs):
                            '"metadata": {\n' + ' ' * kwargs['indent'])[:n]
         assert content[:n] == first_n_simbols
         assert actual == expected
+
+
+def test_file_prefix_formatting(file_prefix_list, example_data, tmp_path):
+    '''Runs a test of the ``file_prefix`` formatting.
+    ..note::
+        Due to the `file_prefix_list` and `example_data` `pytest.fixture`'s
+        this will run multiple tests each with a range of file_prefixes,
+        detectors and event_types. See `suitcase.utils.conftest` for more info.
+    '''
+    collector = example_data()
+    file_prefix = file_prefix_list()
+    artifacts = export(collector, tmp_path, file_prefix=file_prefix)
+
+    for name, doc in collector:
+        if name == 'start':
+            templated_file_prefix = file_prefix.format(
+                start=doc).partition('-')[0]
+            break
+
+    if artifacts:
+        unique_actual = set(str(artifact).split('/')[-1].partition('-')[0]
+                            for artifact in artifacts['stream_data'])
+        assert unique_actual == set([templated_file_prefix])

--- a/suitcase/json_metadata/tests/tests.py
+++ b/suitcase/json_metadata/tests/tests.py
@@ -91,5 +91,5 @@ def test_file_prefix_formatting(file_prefix_list, example_data, tmp_path):
 
     if artifacts:
         unique_actual = set(str(artifact).split('/')[-1].partition('-')[0]
-                            for artifact in artifacts['stream_data'])
+                            for artifact in artifacts['run_metadata'])
         assert unique_actual == set([templated_file_prefix])


### PR DESCRIPTION
This updates the `file_prefix` formatting .

##Previous approach
`file_prefix='{uid}'`
##New approach
`file_prefix='{start[uid]}'`