### PR TITLE
Revert "fix attrs version"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,10 @@ cache:
     - $HOME/.ccache  # https://github.com/travis-ci/travis-ci/issues/5853
 
 install:
-  # record the installed packages before installing suitcase-json-metadata
-  - pip freeze
   # Install this package and the packages listed in requirements.txt.
   - pip install .
   # Install extra requirements for running tests and building docs.
   - pip install -r requirements-dev.txt
-  # record the installed packages after installing suitcase-json-metadata
-  - pip freeze
 
 script:
   - coverage run -m pytest  # Run the tests and check for test coverage.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,8 @@
 codecov
 coverage
 flake8
-ophyd ==1.3.4rc1
+# TEMPORARY UNTIL https://github.com/NSLS-II/ophyd/pull/682 IS RELEASED
+git+git://github.com/NSLS-II/ophyd@ophyd-for-suitcase-utils
 pytest >=3.9
 sphinx
 suitcase-utils[test_fixtures] >=0.1.4rc1

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as readme_file:
 with open(path.join(here, 'requirements.txt')) as requirements_file:
     # Parse requirements.txt, ignoring any commented-out lines.
     requirements = [line for line in requirements_file.read().splitlines()
-                    if not (line.startswith('#') or line.startswith('git+'))]
+                    if not line.startswith('#')]
 
 
 setup(


### PR DESCRIPTION
Reverts bluesky/suitcase-json-metadata#11

Adding `pip freeze` before/after is useful. We should reinstate that after this reversion and probably apply to _all_ our projects.

If someone adds ` git+...` dependency to `requirements.txt`, it seems to be the right thing to do is fail (because `install_requires` can't install from git) not silently skip over the requirement.

I can't think of a situation where we would want a hard pin to an RC as in `ophyd ==1.3.4rc1`. There are situations where we could want `ophyd >=1.3.4rc1`. But I thought that, in this case, we need changes to `ophyd.sim` that we decided not to back-port to the `1.3.x` series, so we'll have to stick with the `ophyd-for-suitcase-utils` branch until `1.4.0` final is out. Thus, I don't think _any_ changes need to be made to suitcase-json-metadata. All the changes we need to make can be done on suitcase-utils, ophyd, and caproto.